### PR TITLE
fixing potential SQLi in Legacy.php

### DIFF
--- a/libs/Legacy/Legacy.php
+++ b/libs/Legacy/Legacy.php
@@ -314,7 +314,8 @@ function nebula_send_to_hubspot($data=array()){
         if ( empty($data['hubspot_vid']) && empty($data['email_address']) ){ //If calling from AJAX we must lookup VID or Email Address
             global $wpdb;
             $nebula_id = get_nebula_id();
-            $vid_and_email = $wpdb->get_results("SELECT hubspot_vid, email_address FROM nebula_visitors WHERE nebula_id LIKE '" . $nebula_id . "' AND email_address <> '' OR hubspot_vid <> ''"); //here
+	    $sql = $wpdb->prepare("SELECT hubspot_vid, email_address FROM nebula_visitors WHERE nebula_id LIKE '"%d"' AND email_address <> '' OR hubspot_vid <> ''", $nebula_id);
+            $vid_and_email = $wpdb->get_results($sql);
             $vid_and_email = (array) $vid_and_email[0];
             $hubspot_vid = $vid_and_email['hubspot_vid'];
             $email_address = $vid_and_email['email_address'];


### PR DESCRIPTION
Since the nebula_id can be user submitted data (see for example Line 1128 in /libs/Utilities/Visitors.php as of commit  7d3ddb5 ), it should be treated as unsafe and potentially harmful. 
The code in /libs/Legacy/Legacy.php should use prepared statements before handing these values to the sql database. 

Best regards,
Alex
