### PR TITLE
Changes date to date_i18n to enable translations

### DIFF
--- a/libs/Functions.php
+++ b/libs/Functions.php
@@ -777,9 +777,9 @@ trait Functions {
 		$day = ( $data['day'] )? date('d', $the_date) . '/' : ''; //If the day should be shown (otherwise, just month and year).
 
 		if ( $data['linked'] && !isset($options['format']) ){
-			return '<span class="posted-on meta-item post-date">' . $label . '<span class="entry-date" datetime="' . date('c', $the_date) . '" itemprop="datePublished" content="' . date('c', $the_date) . '"><a href="' . home_url('/') . date('Y/m', $the_date) . '/">' . date('F', $the_date) . '</a> <a href="' . home_url('/') . date('Y/m', $the_date) . '/' . $day . '">' . date('j', $the_date) . '</a>, <a href="' . home_url('/') . date('Y', $the_date) . '/">' . date('Y', $the_date) . '</a></span>' . $modified_date_html . '</span>';
+			return '<span class="posted-on meta-item post-date">' . $label . '<span class="entry-date" datetime="' . date('c', $the_date) . '" itemprop="datePublished" content="' . date('c', $the_date) . '"><a href="' . home_url('/') . date('Y/m', $the_date) . '/">' . date_i18n('F', $the_date) . '</a> <a href="' . home_url('/') . date('Y/m', $the_date) . '/' . $day . '">' . date('j', $the_date) . '</a>, <a href="' . home_url('/') . date('Y', $the_date) . '/">' . date('Y', $the_date) . '</a></span>' . $modified_date_html . '</span>';
 		} else {
-			return '<span class="posted-on meta-item post-date">' . $label . '<span class="entry-date" datetime="' . date('c', $the_date) . '" itemprop="datePublished" content="' . date('c', $the_date) . '">' . date($data['format'], $the_date) . '</span>' . $modified_date_html . '</span>';
+			return '<span class="posted-on meta-item post-date">' . $label . '<span class="entry-date" datetime="' . date('c', $the_date) . '" itemprop="datePublished" content="' . date('c', $the_date) . '">' . date_i18n($data['format'], $the_date) . '</span>' . $modified_date_html . '</span>';
 		}
 	}
 


### PR DESCRIPTION
## Types of change(s)
feature


## What problem does this address?
https://github.com/chrisblakley/Nebula/issues/1964

## What is the new behavior?
It's expected to use the wordpress default language on post_date. If the date is linked, only the month will be translated and the format will continue, otherwise it will follow the format set on child theme functions.php file and translate aswell.


## Additional information
(Include screenshots if possible)
**Maybe it should be interesting to improve this code so that even the linked date could have a custom format**

Linked true example:
![image](https://user-images.githubusercontent.com/19509037/65269747-2e947c00-daf0-11e9-802d-89a933b42440.png)
Linked false: 
![image](https://user-images.githubusercontent.com/19509037/65269763-381de400-daf0-11e9-9159-4fcd2a7b612f.png)


