### PR TITLE
Expand on nebula->paginate()

### DIFF
--- a/libs/Functions.php
+++ b/libs/Functions.php
@@ -949,19 +949,25 @@ if ( !trait_exists('Functions') ){
 		}
 
 		//Use WP Pagenavi if active, or manually paginate.
-		public function paginate(){
+		public function paginate( $query = false, $args = array() ){
 			if ( function_exists('wp_pagenavi') ){
 				wp_pagenavi();
 			} else {
-				global $wp_query;
+				if( !$query ){
+					global $wp_query;
+					$query = $wp_query;
+				}
+
 				$big = 999999999; //An unlikely integer //PHP 7.4 use numeric separators here
+
+				// Set some defaults if not passed by the $args value...
+				$args['base'] = ($args['base'])?$args['base']:str_replace($big, '%#%', esc_url(get_pagenum_link($big)));
+				$args['format'] = ($args['format'])?$args['format']:'?paged=%#%';
+				$args['current'] = ($args['current'])?$args['current']:max(1, get_query_var('paged'));
+				$args['total'] = ($args['total'])?$args['total']:$query->max_num_pages;
+				
 				echo '<div class="wp-pagination">';
-					echo paginate_links(array(
-						'base' => str_replace($big, '%#%', esc_url(get_pagenum_link($big))),
-						'format' => '?paged=%#%',
-						'current' => max(1, get_query_var('paged')),
-						'total' => $wp_query->max_num_pages
-					));
+					echo paginate_links( $args );
 				echo '</div>';
 			}
 		}


### PR DESCRIPTION
## Types of change(s)
Expands `nebula->paginate()` in 2 ways:

A separate custom query can now be passed instead of relying on the global `$wp_query` for max_num_pages.

Allows for all other standard `$args` to be passed, which can normally be passed to Wordpress `paginate_links()` as outlined here: https://developer.wordpress.org/reference/functions/paginate_links/

## What problem does this address?
When using `nebula->paginate()`, no custom args could be passed and instead relied on the preset values within the function.

When using `nebula->paginate()`, the total number of pages was determined by `$wp_query->max_num_posts`. If paginating a *different custom query* e.g. `$custom_query  = new WP_Query( $args );` this would result in the maximum pages being determined by the wrong query.

## What is the new behavior?
This is a non-breaking change and the new function is backwards compatible with all previous versions. If no query or arguments are passed, the function uses the default values set in the previous version.

`nebula->paginate( object | $query, array | $args )`



