### PR TITLE
Update _helpers.scss .sticky class name to avoid conflict with WP sticky posts

### DIFF
--- a/assets/scss/partials/_helpers.scss
+++ b/assets/scss/partials/_helpers.scss
@@ -164,7 +164,7 @@ hr.nebula-line {display: block; height: 1px; border: 0; border-top: 1px solid #c
 
 ul.list-unstyled {list-style: none; padding-left: 0;}
 
-.sticky {position: sticky; top: 0;} //Sticky requires a top value. Default is set to 0 here.
+.p-sticky {position: sticky; top: 0;} //Sticky requires a top value. Default is set to 0 here.
 
 .pretty-underline {text-decoration-skip-ink: auto;} //Underline does not interfere with character descenders
 


### PR DESCRIPTION
## Types of change(s)
Updates the `.sticky` utility class name to be `.p-sticky`


## What problem does this address?
This class appears to interfere with the default "sticky post" class (`.sticky`) given to _featured/sticky posts_ by default in wordpress.


## What is the new behavior?
The class behaves the same as before, just has a new name.


## Additional information
This may cause breaking changes to anyone already using the `.sticky` class to make an item positioned sticky.

