### PR TITLE
Update Ecommerce.php to ensure $product is an object

### DIFF
--- a/libs/Ecommerce.php
+++ b/libs/Ecommerce.php
@@ -111,6 +111,7 @@ if ( !trait_exists('Ecommerce') ){
 			//View product detail page
 			if ( is_product() ){
 				global $product;
+				if ( ! is_object( $product)) $product = wc_get_product( get_the_ID() );
 				$variation = wc_get_product($product->get_variation_id()); //If no variation, this will appear the same as the product itself
 
 				$product_item = array(


### PR DESCRIPTION
## Types of change(s)
Bug fix/patch


## What problem does this address?
The global `$product` is only an object of class WC_Product when `the_post()` is used. Else, it comes over as a string, causing fatal errors with the rest of the script.


## What is the new behavior?
If the `$product`  is not an object, it performs a lookup for the product by the ID before continuing.

