### PR TITLE
Fix missing argument error

### DIFF
--- a/libs/Security.php
+++ b/libs/Security.php
@@ -281,7 +281,7 @@ if ( !trait_exists('Security') ){
 					$this->ga_send_exception('(Security) spammers.txt has no entries!', false);
 				}
 
-				$this->set_cookie('spam_domain', false);
+				$this->set_cookie('spam_domain', false, $options = null);
 			}
 
 			do_action('qm/info', 'Spam Domain Check Performed');


### PR DESCRIPTION
I get an error from the set_cookie function due to a missing argument

## Types of change(s)
Bug fix


## What is the new behavior?
Doesn't change any behavior - only removes an error that can occur

