### PR TITLE
Update to requested_url function.

### DIFF
--- a/libs/Utilities/Utilities.php
+++ b/libs/Utilities/Utilities.php
@@ -651,20 +651,35 @@ if ( !trait_exists('Utilities') ){
 			return implode("|", $all_domains); //Return a valid hostname regex string
 		}
 
-		//Get the full URL. Not intended for secure use ($_SERVER var can be manipulated by client/server).
-		public function requested_url($host="HTTP_HOST"){ //Can use "SERVER_NAME" as an alternative to "HTTP_HOST".
-			$override = apply_filters('pre_nebula_requested_url', null, $host);
-			if ( isset($override) ){return $override;}
-
-			if ( $this->is_cli() ){
-				return null;
-			}
-
-			$protocol = ( is_ssl() )? 'https' : 'http';
-			$full_url = $protocol . '://' . $this->super->server["$host"] . $this->super->server["REQUEST_URI"];
-
-			return esc_url($full_url);
+		// Get the full URL. Not intended for secure use ($_SERVER var can be manipulated by client/server).
+		public function requested_url($host = "HTTP_HOST") { // Can use "SERVER_NAME" as an alternative to "HTTP_HOST".
+		    $override = apply_filters('pre_nebula_requested_url', null, $host);
+		    if (isset($override)) {
+		        return $override;
+		    }
+		
+		    // Bail early if CLI or no REQUEST_URI
+		    if ($this->is_cli() || empty($this->super->server['REQUEST_URI'])) {
+		        return null;
+		    }
+		
+		    // Check if host key exists
+		    $server = $this->super->server;
+		    if (!isset($server[$host]) || empty($server[$host])) {
+		        // Fall back to SERVER_NAME or return null
+		        if (!empty($server['SERVER_NAME'])) {
+		            $server[$host] = $server['SERVER_NAME'];
+		        } else {
+		            return null;
+		        }
+		    }
+		
+		    $protocol = is_ssl() ? 'https' : 'http';
+		    $full_url = $protocol . '://' . $server[$host] . $server['REQUEST_URI'];
+		
+		    return esc_url($full_url);
 		}
+
 
 		//Separate a URL into it's components.
 		public function url_components($segment="all", $url=null){


### PR DESCRIPTION
Wrapping variables in issets to prevent PHP Warnings from filling up log files.

## Types of change(s)
Bug Fix


## What problem does this address?
random isset() checks to prevent PHP Warnings.


## What is the new behavior?
No breaking changes. Just checking if a var is set before any actions are applied to a null value.


## Additional information
Meh, you know me.

